### PR TITLE
2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@
 [downloads-image]: https://img.shields.io/npm/dm/scmp.svg?style=flat
 [downloads-url]: https://npmjs.org/package/scmp
 
-Safe, constant-time comparison of strings.
+Safe, constant-time comparison of Buffers.
+
+## Changes in v2.x
+Since scmp 2.x, Buffers are now required to be passed as arguments. In 1.x,
+the arguments were assumed to be strings, and were always run through `String()`.
+
+Also, there is a new `crypto.timingSafeEqual()` since Node v6.6.0. If this function
+is available, then that will be used, otherwise a scmp-internal implementation
+will be used.
 
 ## Install
 
@@ -28,9 +36,10 @@ To minimize vulnerability against [timing attacks](http://codahale.com/a-lesson-
 
 ```js
 const scmp = require('scmp');
+const Buffer = require('safe-buffer').Buffer;
 
-const hash      = 'e727d1464ae12436e899a726da5b2f11d8381b26';
-const givenHash = 'e727e1b80e448a213b392049888111e1779a52db';
+const hash      = Buffer.from('e727d1464ae12436e899a726da5b2f11d8381b26', 'utf8');
+const givenHash = Buffer.from('e727e1b80e448a213b392049888111e1779a52db', 'utf8');
 
 if (scmp(hash, givenHash)) {
   console.log('good hash');

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,15 +1,19 @@
 var scmp = require('../');
 
+// use safe-buffer in case Buffer.from in newer versions of node aren't
+// available
+var Buffer = require('safe-buffer').Buffer;
+
 suite('scmp', function() {
-  var HASH1 = 'e727d1464ae12436e899a726da5b2f11d8381b26';
-  var HASH2 = 'f727d1464ae12436e899a726da5b2f11d8381b26';
-  
+  var HASH1 = Buffer.from('e727d1464ae12436e899a726da5b2f11d8381b26', 'utf8');
+  var HASH2 = Buffer.from('f727d1464ae12436e899a726da5b2f11d8381b26', 'utf8');
+
   bench('short-circuit compares', function() {
     HASH1 === HASH2;
   });
-  
+
   bench('scmp compares', function() {
     scmp(HASH1, HASH2);
   });
-  
+
 });

--- a/lib/scmpCompare.js
+++ b/lib/scmpCompare.js
@@ -1,0 +1,8 @@
+module.exports = function scmpCompare (a, b) {
+  var len = a.length;
+  var result = 0;
+  for (var i = 0; i < len; ++i) {
+    result |= a[i] ^ b[i];
+  }
+  return result === 0;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scmp",
   "version": "1.0.2",
-  "description": "safe, constant-time string-comparison",
+  "description": "safe, constant-time comparison of Buffers",
   "main": "index.js",
   "scripts": {
     "test": "mocha",
@@ -24,6 +24,8 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "matcha": "^0.7.0",
-    "mocha": "^3.1.2"
-  }
+    "mocha": "^3.1.2",
+    "safe-buffer": "^5.0.1"
+  },
+  "dependencies": {}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,24 +1,28 @@
-var scmp = require('../');
 var assert = require('assert');
+var scmp = require('../');
+
+// use safe-buffer in case Buffer.from in newer versions of node aren't
+// available
+var Buffer = require('safe-buffer').Buffer;
 
 describe('scmp', function() {
   it('should return true for identical strings', function() {
-    assert(scmp('a', 'a'));
-    assert(scmp('abc', 'abc'));
-    assert(scmp('e727d1464ae12436e899a726da5b2f11d8381b26', 'e727d1464ae12436e899a726da5b2f11d8381b26'));
+    assert(scmp(Buffer.from('a', 'utf8'), Buffer.from('a', 'utf8')));
+    assert(scmp(Buffer.from('abc', 'utf8'), Buffer.from('abc', 'utf8')));
+    assert(scmp(Buffer.from('e727d1464ae12436e899a726da5b2f11d8381b26', 'utf8'), Buffer.from('e727d1464ae12436e899a726da5b2f11d8381b26', 'utf8')));
   });
-  
+
   it('should return false for non-identical strings', function() {
-    assert.ifError(scmp('a', 'b'));
-    assert.ifError(scmp('abc', 'b'));
-    assert.ifError(scmp('e727d1464ae12436e899a726da5b2f11d8381b26', 'e727e1b80e448a213b392049888111e1779a52db'));
+    assert.ifError(scmp(Buffer.from('a', 'utf8'), Buffer.from('b', 'utf8')));
+    assert.ifError(scmp(Buffer.from('abc', 'utf8'), Buffer.from('b', 'utf8')));
+    assert.ifError(scmp(Buffer.from('e727d1464ae12436e899a726da5b2f11d8381b26', 'utf8'), Buffer.from('e727e1b80e448a213b392049888111e1779a52db', 'utf8')));
   });
-  
-  it('should not throw errors for non-strings', function() {
-    assert.ifError(scmp('a', {}));
-    assert.ifError(scmp({}, 'b'));
-    assert.ifError(scmp(1, 2));
-    assert.ifError(scmp(undefined, 2));
-    assert.ifError(scmp(null, 2));
+
+  it('should throw errors for non-Buffers', function() {
+    assert.throws(scmp.bind(null, 'a', {}));
+    assert.throws(scmp.bind(null, {}, 'b'));
+    assert.throws(scmp.bind(null, 1, 2));
+    assert.throws(scmp.bind(null, undefined, 2));
+    assert.throws(scmp.bind(null, null, 2));
   });
 });


### PR DESCRIPTION
* require Buffers as arguments to scmp()
* use new native crypto.timingSafeEqual() on newer versions of node if available